### PR TITLE
Move sync syscall just before luksSuspend

### DIFF
--- a/arch-luks-suspend
+++ b/arch-luks-suspend
@@ -66,9 +66,6 @@ if [[ "$MOUNT_OPTS" ]] && ! [[ "$MOUNT_OPTS" == *nobarrier* || "$MOUNT_OPTS" == 
     mount -o remount,"$MOUNT_OPTS",barrier=0 /
 fi
 
-# Synchronize filesystems before luksSuspend
-sync
-
 # Hand over execution to script inside initramfs
 cd "${INITRAMFS_DIR}"
 chroot . /suspend "$CRYPTNAME"

--- a/initramfs-suspend
+++ b/initramfs-suspend
@@ -5,6 +5,9 @@ cryptname="${1}"
 # Start udev from initramfs
 /usr/lib/systemd/systemd-udevd --daemon --resolve-names=never
 
+# Synchronize filesystems before luksSuspend
+sync
+
 # Suspend root device
 [ -z "${cryptname}" ] || cryptsetup luksSuspend "${cryptname}"
 


### PR DESCRIPTION
This avoids that a following sync syscall in in pm_suspend()
(called when we echo mem > /sys/power/state) hangs forever
in at least one case.

I guess that one case is the following: if tracking access time
is enabled on an ext4 file system, then executing chroot in
arch-luks-suspend will require I/O in the sync syscall in
pm_suspend().